### PR TITLE
Avoid conflict: `no-mixed-operators` / `no-extra-parens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.5.1
+### Changed
+- ESLint conflict between `no-mixed-operators` and `no-extra-parens` resolved.
+
 ## 3.5.0
 ### Added
 - Args to show phpcs warnings/errors in color and show the correct class that
@@ -12,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Rule `Generic.Formatting.MultipleStatementAlignment`, since this did not help for the readability 
   of the code.
-
 
 ## 3.4.0
 ### Added

--- a/src/Youwe/eslintrc.json
+++ b/src/Youwe/eslintrc.json
@@ -80,7 +80,7 @@
         "no-extend-native": 2,
         "no-extra-bind": 2,
         "no-extra-boolean-cast": 2,
-        "no-extra-parens": 2,
+        "no-extra-parens": [2, "all", { "nestedBinaryExpressions": false }],
         "no-extra-semi": 2,
         "no-fallthrough": 2,
         "no-floating-decimal": 2,


### PR DESCRIPTION
The documentation for 'no-mixed-operators' states:

> This rule may conflict with no-extra-parens rule. If you use both this and no-extra-parens rule together, you need to use the nestedBinaryExpressions option of no-extra-parens rule.

https://eslint.org/docs/latest/rules/no-mixed-operators
https://eslint.org/docs/latest/rules/no-extra-parens