### PR TITLE
Add sniff `RequireExplicitBooleanOperatorPrecedence` to the default Youwe coding standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.6.0
+### Added
+- Rule `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence` to improve legibility of code.
+
+### Changed
+- Increase minimum version of `squizlabs/php_codesniffer` package to guarantee `RequireExplicitBooleanOperatorPrecedence` sniff exists.
+
+
 ## 3.5.1
 ### Changed
 - ESLint conflict between `no-mixed-operators` and `no-extra-parens` resolved.
@@ -14,12 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renders the warning/error. This way it's easier to ignore if necessary.
 
 ### Removed
-- Rule `Generic.Formatting.MultipleStatementAlignment`, since this did not help for the readability 
+- Rule `Generic.Formatting.MultipleStatementAlignment`, since this did not help for the readability
   of the code.
 
 ## 3.4.0
 ### Added
-- Constraint for `squizlabs/php_codesniffer` to be compatible with 
+- Constraint for `squizlabs/php_codesniffer` to be compatible with
   magento 2.4.4 and higher coding standards.
 
 ## 3.3.1 - 2022-05-27

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.0 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "phpmd/phpmd": "^2.0",
-        "squizlabs/php_codesniffer": "^3.5.4"
+        "squizlabs/php_codesniffer": "^3.9.0"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/src/GlobalCommon/ruleset.xml
+++ b/src/GlobalCommon/ruleset.xml
@@ -35,6 +35,7 @@
     <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
     <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>


### PR DESCRIPTION
This adds the new `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence` sniff to our standard / default ruleset. See https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/197 for details about this particular sniff.